### PR TITLE
Fix multivalued fields

### DIFF
--- a/src/Opensearchserver/OssResults.php
+++ b/src/Opensearchserver/OssResults.php
@@ -167,7 +167,7 @@ class OssResults
     {
         if(!empty($current[(string) $name]))
         {
-            if(is_string($current[(string) $name]) === true)
+            if(is_array($current[(string) $name]) === false)
             {
                 $firstValue = $current[(string) $name];
                 $current[(string) $name] = array($firstValue);


### PR DESCRIPTION
Multivalued fields are probably present in xml returned by oss query result, but the php return override multivalued fields that have the same key name.

The fix return an array of fieds in that case.
