### PR TITLE
Removed unnecesary break

### DIFF
--- a/src/OpenSearchServer/Response/ResponseFactory.php
+++ b/src/OpenSearchServer/Response/ResponseFactory.php
@@ -68,7 +68,6 @@ class ResponseFactory
                     $response->setValues($response->getJsonValues()->templates);
                 }
                 return $response;
-                break;
          } else if (   is_a($request, 'OpenSearchServer\Synonyms\Get')
                     || is_a($request, 'OpenSearchServer\StopWords\Get')) {
                 $response = new ResponseIterable($response, $request);


### PR DESCRIPTION
Hi,

I've found an unnecessary ```break``` statement. I'm submitting this PR as a necessary step to let library users migrate to PHP7. As you might know, now a ```break``` statement out of a loop or a ```switch``` causes a PHP fatal.

Best,
Christian.